### PR TITLE
Add rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80


### PR DESCRIPTION
This limits all Rust files to 80 columns, which fits nicely on most screens.