### PR TITLE
Implement an API endpoint that gets all spyyts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,20 @@ name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
 
 [[package]]
 name = "serde_json"
@@ -410,6 +424,7 @@ name = "spytter"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "serde",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.15"
+serde = { version = "1.0.160", features = ["derive"] }
 tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["fs"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,25 @@
+use axum::{extract::State, Json};
+use serde::Serialize;
+use std::sync::Arc;
+
+pub struct SpytterState {
+    spyyts: Vec<Spyyt>,
+}
+
+impl SpytterState {
+    pub const fn new() -> Self {
+        Self { spyyts: Vec::new() }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct Spyyt {
+    text: String,
+}
+
+#[allow(clippy::unused_async)]
+pub async fn spyyts(
+    State(state): State<Arc<SpytterState>>,
+) -> Json<Vec<Spyyt>> {
+    Json(state.spyyts.clone())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,24 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::nursery, clippy::pedantic)]
 
-use axum::Router;
+mod api;
+
+use axum::{routing::get, Router};
+use std::sync::Arc;
 use tower_http::services::{ServeDir, ServeFile};
 
 #[tokio::main]
 async fn main() {
+    let state = Arc::new(api::SpytterState::new());
+
     let app = Router::new()
         .route_service("/", ServeFile::new("static/index.html"))
+        .route("/api/spyyts", get(api::spyyts))
         .fallback_service(
             ServeDir::new("static")
                 .not_found_service(ServeFile::new("static/404.html")),
-        );
+        )
+        .with_state(state);
 
     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
         .serve(app.into_make_service())


### PR DESCRIPTION
However, since there is no way to *create* spyyts yet, this just functions as an overcomplicated way to return `[]`.